### PR TITLE
Updates to support vue 2.0

### DIFF
--- a/vue-sortable.js
+++ b/vue-sortable.js
@@ -13,10 +13,10 @@
   vSortable.config = {}
 
   vSortable.install = function (Vue) {
-    Vue.directive('sortable', function (options) {
+    Vue.directive('sortable', function (el, options) {
       options = options || {}
 
-      var sortable = new Sortable(this.el, options)
+      var sortable = new Sortable(el, options)
 
       if (this.arg && !this.vm.sortable) {
         this.vm.sortable = {}


### PR DESCRIPTION
I haven't tested event hooks, but this minor change allows the directive to run in Vue 2.0 and I can drag stuff around and sort.

Since I haven't added any test, it's probably not ready for a full merge, but hopefully this will help get the ball rolling.